### PR TITLE
jQuery compatibility: 'mozilla' for FF

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -71,6 +71,7 @@
     if (gecko) {
       var o = {
           gecko: t
+        , mozilla: t
         , version: ua.match(/firefox\/(\d+(\.\d+)?)/i)[1]
       }
       if (firefox) o.firefox = t


### PR DESCRIPTION
noticed this while trying to use a small jQuery plugin with Ender that uses browser detection through `$.browser`
