### PR TITLE
check first for commonjs rather than AMD

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -1,7 +1,7 @@
-!function (name, definition) {
-  if (typeof define == 'function') define(definition)
-  else if (typeof module != 'undefined' && module.exports) module.exports['browser'] = definition()
-  else this[name] = definition()
+!function (name, definition, context) {
+  if (typeof module != 'undefined' && module.exports) module.exports = definition()
+  else if (typeof context['define'] == 'function' && context['define']['amd']) define(name, definition)
+  else context[name] = definition()
 }('bowser', function () {
   /**
     * navigator.userAgent =>
@@ -113,4 +113,4 @@
   } else bowser.x = t
 
   return bowser
-})
+}, this)


### PR DESCRIPTION
It will make a difference for me if this check first 
for common.js module system rather than AMD module system.

This is exactly as you do in other projects like qwery, bean, 
reqwest and bonzo.

Thanks,
