### PR TITLE
Only try to extract webkitVersion if that matches. 

### DIFF
--- a/bowser.js
+++ b/bowser.js
@@ -74,20 +74,22 @@
       }
       return o
     }
-    if (android) return {
-        webkit: t
-      , android: t
-      , mobile: t
-      , version: ua.match(webkitVersion)[1]
-    }
-    if (safari) return {
-        webkit: t
-      , safari: t
-      , version: ua.match(webkitVersion)[1]
-    }
-    if (opera) return {
-        opera: t
-      , version: ua.match(webkitVersion)[1]
+    if (webkitVersion.test(ua)) {
+      if (android) return {
+          webkit: t
+        , android: t
+        , mobile: t
+        , version: ua.match(webkitVersion)[1]
+      }
+      if (safari) return {
+          webkit: t
+        , safari: t
+        , version: ua.match(webkitVersion)[1]
+      }
+      if (opera) return {
+          opera: t
+        , version: ua.match(webkitVersion)[1]
+      }
     }
     if (gecko) {
       o = {
@@ -96,6 +98,10 @@
         , version: ua.match(/firefox\/(\d+(\.\d+)?)/i)[1]
       }
       if (firefox) o.firefox = t
+      if (android) {
+        o.android = t
+        o.mobile = t
+      }
       return o
     }
     if (seamonkey) return {


### PR DESCRIPTION
This pull request fixes an exception on Firefox on Android. It can't be assumed that because a user agent matches the string Android, that it is a Webkit browser. 
