### PR TITLE
Add IE11 support + avoid exception when unable to match UA

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -9,6 +9,7 @@
     * Opera:   "Opera/9.80 (Macintosh; Intel Mac OS X 10.6.7; U; en) Presto/2.7.62 Version/11.01"
     * Safari:  "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_7; en-us) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1"
     * IE:      "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)"
+    * IE>=11:  "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; Media Center PC 6.0; rv:11.0) like Gecko"
     * Firefox: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0) Gecko/20100101 Firefox/4.0"
     * iPhone:  "Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5"
     * iPad:    "Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5",
@@ -18,7 +19,7 @@
 
   var ua = navigator.userAgent
     , t = true
-    , ie = /msie/i.test(ua)
+    , ie = /(msie|trident)/i.test(ua)
     , chrome = /chrome/i.test(ua)
     , safari = /safari/i.test(ua) && !chrome
     , iphone = /iphone/i.test(ua)
@@ -36,7 +37,7 @@
 
     if (ie) return {
         msie: t
-      , version: ua.match(/msie (\d+(\.\d+)?);/i)[1]
+      , version: ua.match(/(msie |rv:)(\d+(\.\d+)?)/i)[2]
     }
     if (chrome) return {
         webkit: t


### PR DESCRIPTION
The user agent has changed considerably in IE11 and it no longer contains the "MSIE x.y" part which bowser detects. Microsoft has been using "Trident/x.0" in the user agent consistently since IE8 and that isn't changed with IE11. Also, the version number seems to be included near the end now, using the format "rv:x.y", just like Firefox has been doing since v5.0.

I changed the IE regex to match either MSIE or Trident (case-insensitively), and changed the version number regex to read the "x.y" number just after either "MSIE " or "rv:".

I know IE11 still isn't final and that its user agent might still change, but bowser right now raises an exception on load (when trying to read bowser.msie for graded browser support) and breaks every page it's included on. While that's due primarily to the fact that detect() returns undefined if no browser matches (which I also fixed in the first commit), I figured I could go ahead and add IE11 support too.

Thanks!
