### PR TITLE
Update typings.d.ts, straight from DefinitelyTyped. fix #182

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,54 +1,104 @@
-export const name: string
-export const osversion: string
-export const version: string
+// Type definitions for Bowser 1.x
+// Project: https://github.com/lancedikson/bowser
+// Definitions by: Paulo Cesar <https://github.com/pocesar>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// grades
-export const a: boolean
-export const b: boolean
-export const c: boolean
+declare const bowser: bowser.IBowser;
+export = bowser;
+export as namespace bowser;
 
-// engines
-export const android: boolean
-export const bada: boolean
-export const blackberry: boolean
-export const chrome: boolean
-export const firefox: boolean
-export const gecko: boolean
-export const ios: boolean
-export const msie: boolean
-export const msedge: boolean
-export const opera: boolean
-export const phantom: boolean
-export const safari: boolean
-export const sailfish: boolean
-export const seamonkey: boolean
-export const silk: boolean
-export const tizen: boolean
-export const webkit: boolean
-export const webos: boolean
-export const mobile: boolean
-export const tablet: boolean
+declare namespace bowser {
 
-// operating systems
-export const chromeos: boolean
-export const iphone: boolean
-export const ipad: boolean
-export const ipod: boolean
-export const firefoxos: boolean
-export const linux: boolean
-export const mac: boolean
-export const touchpad: boolean
-export const windows: boolean
-export const windowsphone: boolean
+    export interface IBowserOS {
+        mac: boolean;
+        /**other than Windows Phone */
+        windows: boolean;
+        windowsphone: boolean;
+        /**other than android, chromeos, webos, tizen, and sailfish */
+        linux: boolean;
+        chromeos: boolean;
+        android: boolean;
+        /** also sets one of iphone/ipad/ipod */
+        ios: boolean;
+        blackberry: boolean;
+        firefoxos: boolean;
+        /** may also set touchpad */
+        webos: boolean;
+        bada: boolean;
+        tizen: boolean;
+        sailfish: boolean;
+    }
 
-export function test(browserList: Flag[]): boolean
-export function isUnsupportedBrowser(minVersions:Object, strictMode?:Boolean, ua?:string): boolean
+    export interface IBowserVersions {
+        chrome: boolean;
+        firefox: boolean;
+        msie: boolean;
+        msedge: boolean;
+        safari: boolean;
+        android: boolean;
+        ios: boolean;
+        opera: boolean;
+        phantom: boolean;
+        blackberry: boolean;
+        webos: boolean;
+        silk: boolean;
+        bada: boolean;
+        tizen: boolean;
+        seamonkey: boolean;
+        sailfish: boolean;
+        ucbrowser: boolean;
+        qupzilla: boolean;
+        vivaldi: boolean;
+        sleipnir: boolean;
+        kMeleon: boolean;
+    }
 
-export type Flag = "a" | "b" | "c" | "android" | "bada" | "blackberry"
-                 | "chrome" | "firefox" | "gecko" | "ios" | "msie"
-                 | "msedge" | "opera" | "phantom" | "safari"
-                 | "sailfish" | "seamonkey" | "silk" | "tizen"
-                 | "webkit" | "webos" | "chromeos" | "iphone"
-                 | "ipad" | "ipod" | "firefoxos" | "linux" | "mac"
-                 | "touchpad" | "windows" | "windowsphone"
+    export interface IBowserEngines {
+        /** IE <= 11 */
+        msie: boolean;
+        /**Chrome 0-27, Android <4.4, iOs, BB, etc. */
+        webkit: boolean;
+        /**Chrome >=28, Android >=4.4, Opera, etc. */
+        blink: boolean;
+        /**Firefox, etc. */
+        gecko: boolean;
+        /** IE > 11 */
+        msedge: boolean;
+        /** If a tablet device is detected, the flag tablet is set instead of mobile. */
+        tablet: boolean;
+        /** All detected mobile OSes are additionally flagged mobile, unless it's a tablet */
+        mobile: boolean;
 
+    }
+
+    export interface IBowserGrade {
+        /** Grade A browser */
+        a: boolean;
+        /** Grade C browser */
+        c: boolean;
+        /** Grade X browser */
+        x: boolean;
+        /**A human readable name for this browser. E.g. 'Chrome', '' */
+        name: string;
+        /**Version number for the browser. E.g. '32.0' */
+        version: string|number;
+        osversion: string|number;
+    }
+
+    export interface IBowserDetection extends IBowserGrade, IBowserEngines, IBowserOS, IBowserVersions { }
+
+    export interface IBowserMinVersions {
+        // { msie: "11", "firefox": "4" }
+        [index: string]: string;
+    }
+
+    export interface IBowser extends IBowserDetection {
+        (): IBowserDetection;
+        test(browserList: string[]): boolean;
+        _detect(ua: string): IBowser;
+        compareVersions(versions: string[]): number;
+        check(minVersions: IBowserMinVersions, strictMode?: boolean|string, ua?: string): Boolean;
+        isUnsupportedBrowser(minVersions: IBowserMinVersions, strictMode?: boolean|string, ua?: string): boolean;
+    }
+
+}


### PR DESCRIPTION
Hey there,

while using `bowser` with TypeScript I've found that the included typings file is now obsolete.

Instead of fixing it manually, I grabbed the one offered on (DefinitelyTyped)[https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/bowser/index.d.ts] which is already very complete.

I left all the attributions to the original author, since I really did no work here 😄 

Thanks!