### PR TITLE
Fix Chrome detection for Android 8 OPR6 build num

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -56,7 +56,7 @@
       , opera: t
       , version: versionIdentifier || getFirstMatch(/(?:opera|opr|opios)[\s\/](\d+(\.\d+)?)/i)
       }
-    } else if (/opr|opios/i.test(ua)) {
+    } else if (/opr\/|opios/i.test(ua)) {
       // a new Opera
       result = {
         name: 'Opera'
@@ -351,7 +351,7 @@
         default: return undefined
       }
     }
-    
+
     // OS version extraction
     var osVersion = '';
     if (result.windows) {

--- a/src/useragents.js
+++ b/src/useragents.js
@@ -7,7 +7,16 @@
  */
 module.exports.useragents = {
     Chrome: {
-      'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 9 Build/LMY48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36': {
+      'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36': {
+        chrome: true
+      , android: true
+      , osversion: '8.0.0'
+      , mobile: true
+      , version: '60.0'
+      , blink: true
+      , a: true
+      }
+    , 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 9 Build/LMY48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36': {
         chrome: true
       , android: true
       , osversion: '5.1.1'
@@ -206,7 +215,24 @@ module.exports.useragents = {
       }
     }
   , Opera: {
-      'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721': {
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36 OPR/47.0.2631.55': {
+        opera: true
+      , blink: true
+      , mac: true
+      , osversion: '10.11.6'
+      , version: '47.0'
+      , a: true
+      }
+    , 'Mozilla/5.0 (Linux; Android 8.0; Nexus 6P Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36 OPR/42.7.2246.114996': {
+        opera: true
+      , blink: true
+      , android: true
+      , osversion: '8.0'
+      , mobile: true
+      , version: '42.7'
+      , a: true
+      }
+    , 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721': {
         opera: true
       , blink: true
       , android: true


### PR DESCRIPTION
One of Android 8's build numbers is 'opr6.170623.013'. This is expressed
in the user agent as:

"Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPR6.170623.013)
AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile
Safari/537.36"

Because this library detects the Opera browser if "opera", "opr", or
"opios" is contained in the user agent, the above user agent string is
incorrectly detected as a versionless Opera, instead of Chrome 60.

This commit changes the detection of "opr" to require a trailing slash
'/' character. This works because build numbers are expressed as
Build/X..., whereas Opera versions are expressed as OPR/X.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lancedikson/bowser/195)
<!-- Reviewable:end -->
