### PR TITLE
register detect public method

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -611,5 +611,10 @@
    */
   bowser._detect = detect;
 
+  /*
+   * Set our detect public method to the main bowser object
+   * This is needed to implement bowser in server side
+   */
+  bowser.detect = detect;
   return bowser
 });


### PR DESCRIPTION
Defined `detect` public method in order to be able to use it in server side.

for instance:

```js
import bowser from 'bowser'
[...]
const ua = bowser.detect(userAgent)
domain.config('isMobile', ua.mobile)
[...]
```

i did not delete the private method because i don't know if this would break something.
let me know if it's fine for you, or we can do it in an other better way.
Cheeers
Joan