### PR TITLE
Add parser.some()

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -427,6 +427,15 @@ class Parser {
   is(anything) {
     return this.isBrowser(anything) || this.isOS(anything) || this.isPlatform(anything);
   }
+
+  /**
+   * Check if any of the given values satifies this.is(anything)
+   * @param {String[]} anythings
+   * @returns {Boolean}
+   */
+  some(anythings = []) {
+    return anythings.some(anything => this.is(anything));
+  }
 }
 
 export default Parser;

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -114,3 +114,11 @@ test('Parser.is should pass', (t) => {
   t.is(parser.is('desktop'), true);
   t.is(parser.is('macos'), true);
 });
+
+test('Parser.some should pass', (t) => {
+  t.is(parser.some(['opera', 'chrome', 'firefox']), true);
+  t.is(parser.some(['macos', 'windows']), true);
+  t.is(parser.some(['chrome', 'firefox']), false);
+  t.is(parser.some([]), false);
+  t.is(parser.some(), false);
+});


### PR DESCRIPTION
Hi @lancedikson !

What do you think about this? It adds the function `Parser.some()` to be able to check if the browser satisfies any of the given options.

The function is called `some` to mimic the native array convention: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some

This will allow us to change code like this:

```javascript
const supportsPinch =
  browser.safari
  || browser.chrome
  || browser.opera
  || browser.firefox
```

for this:

```javascript
const supportsPinch = browser.some(['safari', 'chrome', 'opera', 'firefox']);
```