### PR TITLE
Support non strict equality in satisfies method

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lint": "eslint ./src",
     "testem": "testem",
     "test": "nyc --reporter=html --reporter=text ava",
+    "test:watch": "ava --watch",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "docs": "jsdoc -c jsdoc.json"
   },

--- a/src/parser.js
+++ b/src/parser.js
@@ -395,7 +395,7 @@ class Parser {
   }
 
   compareVersion(version) {
-    let expectedResult = 0;
+    let expectedResults = [0];
     let comparableVersion = version;
     let isLoose = false;
 
@@ -405,12 +405,19 @@ class Parser {
       return void 0;
     }
 
-    if (version[0] === '>') {
-      expectedResult = 1;
+    if (version[0] === '>' || version[0] === '<') {
       comparableVersion = version.substr(1);
-    } else if (version[0] === '<') {
-      expectedResult = -1;
-      comparableVersion = version.substr(1);
+      if (version[1] === '=') {
+        isLoose = true;
+        comparableVersion = version.substr(2);
+      } else {
+        expectedResults = [];
+      }
+      if (version[0] === '>') {
+        expectedResults.push(1);
+      } else {
+        expectedResults.push(-1);
+      }
     } else if (version[0] === '=') {
       comparableVersion = version.substr(1);
     } else if (version[0] === '~') {
@@ -418,7 +425,9 @@ class Parser {
       comparableVersion = version.substr(1);
     }
 
-    return compareVersions(currentBrowserVersion, comparableVersion, isLoose) === expectedResult;
+    return expectedResults.indexOf(
+      compareVersions(currentBrowserVersion, comparableVersion, isLoose),
+    ) > -1;
   }
 
   isOS(osName) {

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -63,6 +63,14 @@ test('Parser.satisfies should make simple comparisons', (t) => {
   t.is(parser.satisfies({ opera: '<44' }), true);
   t.is(parser.satisfies({ opera: '=43.0.2442.1165' }), true);
   t.is(parser.satisfies({ opera: '~43.0' }), true);
+  t.is(parser.satisfies({ opera: '>=43' }), true);
+  t.is(parser.satisfies({ opera: '<=43' }), true);
+  t.is(parser.satisfies({ opera: '>=43.0' }), true);
+  t.is(parser.satisfies({ opera: '>=43.0.2442.1165' }), true);
+  t.is(parser.satisfies({ opera: '<=43.0.2442.1165' }), true);
+  t.is(parser.satisfies({ opera: '>=43.0.2443' }), false);
+  t.is(parser.satisfies({ opera: '<=43.0.2443' }), true);
+  t.is(parser.satisfies({ opera: '>=43.0.2441' }), true);
   t.is(parser.satisfies({ opera: '~43' }), true);
 });
 


### PR DESCRIPTION
Issue #274

I'm waiting for feedback. I'm not sure about using `indexOf` which is not supported but ie8. Though, I don't know which browsers should be supported by this library.