### PR TITLE
Support Android version names, Recognise Huawei devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ More of API and possibilities you will find in the `docs` folder.
 If you'd like to contribute a change to bowser, modify the files in `src/`, then run the following (you'll need node + npm installed):
 
 ``` sh
-$ npm install
-$ npm test
+$ npm install #build
+$ npm test #run tests
 ```
 
 ### Adding tests

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If you'd like to contribute a change to bowser, modify the files in `src/`, then
 ``` sh
 $ npm install #build
 $ npm test #run tests
+$ npm run lint #check lint rules
 ```
 
 ### Adding tests

--- a/src/parser-os.js
+++ b/src/parser-os.js
@@ -1,6 +1,7 @@
 import {
   getFirstMatch,
   getWindowsVersionName,
+  getAndroidVersionName,
 } from './utils';
 
 export default [
@@ -65,10 +66,15 @@ export default [
     },
     describe(ua) {
       const version = getFirstMatch(/android[\s/-](\d+(\.\d+)*)/i, ua);
-      return {
+      const versionName = getAndroidVersionName(version);
+      const os = {
         name: 'Android',
-        version,
+        version
       };
+      if (versionName) {
+          os.versionName = versionName;
+      }
+      return os;
     },
   },
 

--- a/src/parser-os.js
+++ b/src/parser-os.js
@@ -72,7 +72,7 @@ export default [
         version
       };
       if (versionName) {
-          os.versionName = versionName;
+        os.versionName = versionName;
       }
       return os;
     },

--- a/src/parser-os.js
+++ b/src/parser-os.js
@@ -69,7 +69,7 @@ export default [
       const versionName = getAndroidVersionName(version);
       const os = {
         name: 'Android',
-        version
+        version,
       };
       if (versionName) {
         os.versionName = versionName;

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -16,13 +16,13 @@ export default [
   {
     test: [/huawei/i],
     describe(ua) {
-      const model = getFirstMatch(/(can\-l01)/i, ua) && "Nova";
+      const model = getFirstMatch(/(can-l01)/i, ua) && 'Nova';
       const platform = {
         type: TYPES_LABELS.mobile,
-        vendor: 'Huawei'
+        vendor: 'Huawei',
       };
       if (model) {
-          platform.model = model;
+        platform.model = model;
       }
       return platform;
     },

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -12,6 +12,22 @@ const TYPES_LABELS = {
  */
 
 export default [
+  /* Huawei */
+  {
+    test: [/huawei/i],
+    describe(ua) {
+      const model = getFirstMatch(/(can\-l01)/i, ua) && "Nova";
+      const platform = {
+        type: TYPES_LABELS.mobile,
+        vendor: 'Huawei'
+      };
+      if (model) {
+          platform.model = model;
+      }
+      return platform;
+    },
+  },
+
   /* Nexus Tablet */
   {
     test: [/nexus\s*(?:7|8|9|10).*/i],

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,7 +78,8 @@ class Utils {
   static getAndroidVersionName(version) {
     const v = version.split('.').splice(0, 2).map(function(s) {
         return parseInt(s) || 0;
-    }).push(0);
+    });
+    v.push(0);
     if (v[0] == 1 && v[1] < 5) return undefined;
     if (v[0] == 1 && v[1] < 6) return "Cupcake";
     if (v[0] == 1 && v[1] >= 6) return "Donut";

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,24 +76,24 @@ class Utils {
    * @return {string} versionName
    */
   static getAndroidVersionName(version) {
-    const v = version.split('.').splice(0, 2).map(function(s) {
-        return parseInt(s) || 0;
+    const v = version.split('.').splice(0, 2).map((s) => {
+      return parseInt(s, 10) || 0;
     });
     v.push(0);
-    if (v[0] == 1 && v[1] < 5) return undefined;
-    if (v[0] == 1 && v[1] < 6) return "Cupcake";
-    if (v[0] == 1 && v[1] >= 6) return "Donut";
-    if (v[0] == 2 && v[1] < 2) return "Eclair";
-    if (v[0] == 2 && v[1] == 2) return "Froyo";
-    if (v[0] == 2 && v[1] > 2) return "Gingerbread";
-    if (v[0] == 3) return "Honeycomb";
-    if (v[0] == 4 && v[1] < 1) return "Ice Cream Sandwich";
-    if (v[0] == 4 && v[1] < 4) return "Jelly Bean";
-    if (v[0] == 4 && v[1] >= 4) return "KitKat";
-    if (v[0] == 5) return "Lollipop";
-    if (v[0] == 6) return "Marshmallow";
-    if (v[0] == 7) return "Nougat";
-    if (v[0] == 8) return "Oreo";
+    if (v[0] === 1 && v[1] < 5) return undefined;
+    if (v[0] === 1 && v[1] < 6) return "Cupcake";
+    if (v[0] === 1 && v[1] >= 6) return "Donut";
+    if (v[0] === 2 && v[1] < 2) return "Eclair";
+    if (v[0] === 2 && v[1] === 2) return "Froyo";
+    if (v[0] === 2 && v[1] > 2) return "Gingerbread";
+    if (v[0] === 3) return "Honeycomb";
+    if (v[0] === 4 && v[1] < 1) return "Ice Cream Sandwich";
+    if (v[0] === 4 && v[1] < 4) return "Jelly Bean";
+    if (v[0] === 4 && v[1] >= 4) return "KitKat";
+    if (v[0] === 5) return "Lollipop";
+    if (v[0] === 6) return "Marshmallow";
+    if (v[0] === 7) return "Nougat";
+    if (v[0] === 8) return "Oreo";
     return undefined;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,24 +76,22 @@ class Utils {
    * @return {string} versionName
    */
   static getAndroidVersionName(version) {
-    const v = version.split('.').splice(0, 2).map((s) => {
-      return parseInt(s, 10) || 0;
-    });
+    const v = version.split('.').splice(0, 2).map(s => parseInt(s, 10) || 0);
     v.push(0);
     if (v[0] === 1 && v[1] < 5) return undefined;
-    if (v[0] === 1 && v[1] < 6) return "Cupcake";
-    if (v[0] === 1 && v[1] >= 6) return "Donut";
-    if (v[0] === 2 && v[1] < 2) return "Eclair";
-    if (v[0] === 2 && v[1] === 2) return "Froyo";
-    if (v[0] === 2 && v[1] > 2) return "Gingerbread";
-    if (v[0] === 3) return "Honeycomb";
-    if (v[0] === 4 && v[1] < 1) return "Ice Cream Sandwich";
-    if (v[0] === 4 && v[1] < 4) return "Jelly Bean";
-    if (v[0] === 4 && v[1] >= 4) return "KitKat";
-    if (v[0] === 5) return "Lollipop";
-    if (v[0] === 6) return "Marshmallow";
-    if (v[0] === 7) return "Nougat";
-    if (v[0] === 8) return "Oreo";
+    if (v[0] === 1 && v[1] < 6) return 'Cupcake';
+    if (v[0] === 1 && v[1] >= 6) return 'Donut';
+    if (v[0] === 2 && v[1] < 2) return 'Eclair';
+    if (v[0] === 2 && v[1] === 2) return 'Froyo';
+    if (v[0] === 2 && v[1] > 2) return 'Gingerbread';
+    if (v[0] === 3) return 'Honeycomb';
+    if (v[0] === 4 && v[1] < 1) return 'Ice Cream Sandwich';
+    if (v[0] === 4 && v[1] < 4) return 'Jelly Bean';
+    if (v[0] === 4 && v[1] >= 4) return 'KitKat';
+    if (v[0] === 5) return 'Lollipop';
+    if (v[0] === 6) return 'Marshmallow';
+    if (v[0] === 7) return 'Nougat';
+    if (v[0] === 8) return 'Oreo';
     return undefined;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,6 +52,51 @@ class Utils {
   }
 
   /**
+   * Get Android version name
+   *    1.5 - Cupcake
+   *    1.6 - Donut
+   *    2.0 - Eclair
+   *    2.1 - Eclair
+   *    2.2 - Froyo
+   *    2.x - Gingerbread
+   *    3.x - Honeycomb
+   *    4.0 - Ice Cream Sandwich
+   *    4.1 - Jelly Bean
+   *    4.4 - KitKat
+   *    5.x - Lollipop
+   *    6.x - Marshmallow
+   *    7.x - Nougat
+   *    8.x - Oreo
+   *    9.x - ?
+   *
+   * @example
+   *   getAndroidVersionName("7.0") // 'Nougat'
+   *
+   * @param  {string} version
+   * @return {string} versionName
+   */
+  static getAndroidVersionName(version) {
+    const v = version.split('.').splice(0, 2).map(function(s) {
+        return parseInt(s) || 0;
+    }).push(0);
+    if (v[0] == 1 && v[1] < 5) return undefined;
+    if (v[0] == 1 && v[1] < 6) return "Cupcake";
+    if (v[0] == 1 && v[1] >= 6) return "Donut";
+    if (v[0] == 2 && v[1] < 2) return "Eclair";
+    if (v[0] == 2 && v[1] == 2) return "Froyo";
+    if (v[0] == 2 && v[1] > 2) return "Gingerbread";
+    if (v[0] == 3) return "Honeycomb";
+    if (v[0] == 4 && v[1] < 1) return "Ice Cream Sandwich";
+    if (v[0] == 4 && v[1] < 4) return "Jelly Bean";
+    if (v[0] == 4 && v[1] >= 4) return "KitKat";
+    if (v[0] == 5) return "Lollipop";
+    if (v[0] == 6) return "Marshmallow";
+    if (v[0] == 7) return "Nougat";
+    if (v[0] == 8) return "Oreo";
+    return undefined;
+  }
+
+  /**
    * Get version precisions count
    *
    * @example

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -1944,6 +1944,7 @@
         os: 
           name: "Android"
           version: "4.4.2"
+          versionName: "KitKat"
         platform: 
           type: "tablet"
           vendor: "Nexus"
@@ -1959,6 +1960,7 @@
         os: 
           name: "Android"
           version: "4.3"
+          versionName: "Jelly Bean"
         platform: 
           type: "mobile"
           vendor: "Nexus"
@@ -1974,6 +1976,7 @@
         os: 
           name: "Android"
           version: "4.2"
+          versionName: "Jelly Bean"
         platform: 
           type: "tablet"
           vendor: "Nexus"
@@ -1989,6 +1992,7 @@
         os: 
           name: "Android"
           version: "3.2"
+          versionName: "Honeycomb"
         platform: 
           type: "tablet"
         engine: 
@@ -2003,6 +2007,7 @@
         os: 
           name: "Android"
           version: "2.3.4"
+          versionName: "Gingerbread"
         platform: 
           type: "mobile"
         engine: 
@@ -2017,6 +2022,7 @@
         os: 
           name: "Android"
           version: "1.6"
+          versionName: "Donut"
         platform: 
           type: "mobile"
         engine: 
@@ -2254,6 +2260,7 @@
         os: 
           name: "Android"
           version: "4.1.2"
+          versionName: "Jelly Bean"
         platform: 
           type: "tablet"
         engine: 
@@ -2445,6 +2452,7 @@
         os: 
           name: "Android"
           version: "5.0.2"
+          versionName: "Lollipop"
         platform: 
           type: "mobile"
         engine: 
@@ -2474,6 +2482,7 @@
         os:
           name: "Android"
           version: "6.0"
+          versionName: "Marshmallow"
         platform:
           type: "mobile"
         engine:
@@ -2488,6 +2497,7 @@
         os:
           name: "Android"
           version: "7.1.1"
+          versionName: "Nougat"
         platform:
           type: "tablet"
         engine:

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -1,6 +1,22 @@
 ---
   Chrome: 
     - 
+      ua: "Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36"
+      spec:
+        browser:
+          name: "Chrome"
+          version: "71.0.3578.99"
+        os:
+          name: "Android"
+          version: "7.0"
+          versionName: "Nougat"
+        platform:
+          type: "mobile"
+          vendor: "Huawei"
+          model: "Nova"
+        engine:
+          name: "Blink"
+    - 
       ua: "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 9 Build/LMY48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36"
       spec: 
         browser: 
@@ -9,6 +25,7 @@
         os: 
           name: "Android"
           version: "5.1.1"
+          versionName: "Lollipop"
         platform: 
           type: "tablet"
           vendor: "Nexus"
@@ -23,6 +40,7 @@
         os: 
           name: "Android"
           version: "4.4.2"
+          versionName: "KitKat"
         platform: 
           type: "tablet"
           vendor: "Nexus"
@@ -37,6 +55,7 @@
         os: 
           name: "Android"
           version: "4.3"
+          versionName: "Jelly Bean"
         platform: 
           type: "mobile"
           vendor: "Nexus"
@@ -51,6 +70,7 @@
         os: 
           name: "Android"
           version: "4.1"
+          versionName: "Jelly Bean"
         platform: 
           type: "mobile"
           vendor: "Nexus"
@@ -66,6 +86,7 @@
         os: 
           name: "Android"
           version: "4.0.3"
+          versionName: "Ice Cream Sandwich"
         platform: 
           type: "tablet"
         engine: 
@@ -80,6 +101,7 @@
         os: 
           name: "Android"
           version: "4.0.3"
+          versionName: "Ice Cream Sandwich"
         platform: 
           type: "mobile"
           vendor: "Nexus"
@@ -237,6 +259,7 @@
         os: 
           name: "Android"
           version: "5.0.2"
+          versionName: "Lollipop"
         platform: 
           type: "tablet"
         engine: 
@@ -250,6 +273,7 @@
         os: 
           name: "Android"
           version: "6.0.99"
+          versionName: "Marshmallow"
         platform: 
           type: "tablet"
         engine: 
@@ -263,6 +287,7 @@
         os:
           name: "Android"
           version: "7.0"
+          versionName: "Nougat"
         platform:
           type: "mobile"
           vendor: "Nexus"
@@ -277,6 +302,7 @@
         os:
           name: "Android"
           version: "8.0.0"
+          versionName: "Oreo"
         platform:
           type: "mobile"
         engine:
@@ -291,6 +317,7 @@
         os: 
           name: "Android"
           version: "4.0.3"
+          versionName: "Ice Cream Sandwich"
         platform: 
           type: "tablet"
           vendor: "Amazon"
@@ -322,6 +349,7 @@
         os: 
           name: "Android"
           version: "2.3.4"
+          versionName: "Gingerbread"
         platform: 
           type: "tablet"
           vendor: "Amazon"
@@ -353,6 +381,7 @@
         os: 
           name: "Android"
           version: "4.4.2"
+          versionName: "KitKat"
         platform: 
           type: "tablet"
           vendor: "Nexus"
@@ -367,6 +396,7 @@
         os: 
           name: "Android"
           version: "4.3"
+          versionName: "Jelly Bean"
         platform: 
           type: "mobile"
           vendor: "Nexus"
@@ -395,6 +425,7 @@
         os: 
           name: "Android"
           version: "4.3"
+          versionName: "Jelly Bean"
         platform: 
           type: "mobile"
         engine: 
@@ -409,6 +440,7 @@
         os: 
           name: "Android"
           version: "4.4.2"
+          versionName: "KitKat"
         platform: 
           type: "tablet"
         engine: 
@@ -588,6 +620,7 @@
         os: 
           name: "Android"
           version: "6.0"
+          versionName: "Marshmallow"
         platform: 
           type: "mobile"
         engine: 
@@ -633,6 +666,7 @@
         os: 
           name: "Android"
           version: "5.1.1"
+          versionName: "Lollipop"
         platform: 
           type: "mobile"
           vendor: "Nexus"
@@ -1309,6 +1343,7 @@
         os:
           name: "Android"
           version: "8.0"
+          versionName: "Oreo"
         platform:
           type: "mobile"
         engine:


### PR DESCRIPTION
Added **os.versionName** support for Android
   *    1.5 - Cupcake
   *    1.6 - Donut
   *    2.0 - Eclair
   *    2.1 - Eclair
   *    2.2 - Froyo
   *    2.x - Gingerbread
   *    3.x - Honeycomb
   *    4.0 - Ice Cream Sandwich
   *    4.1 - Jelly Bean
   *    4.4 - KitKat
   *    5.x - Lollipop
   *    6.x - Marshmallow
   *    7.x - Nougat
   *    8.x - Oreo
   *    9.x - ?

Added **platform.vendor** and  **platform.model** support for Huawei Nova
`Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36`