### PR TITLE
Added support for Googlebot recognition

### DIFF
--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -31,6 +31,23 @@ import {
 const commonVersionIdentifier = /version\/(\d+(\.?_?\d+)+)/i;
 
 const browsersList = [
+  /* Googlebot */
+  {
+    test: [/googlebot/i],
+    describe(ua) {
+      const browser = {
+        name: 'Googlebot',
+      };
+      const version = getFirstMatch(/googlebot\/(\d+(\.\d+))/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+
+      if (version) {
+        browser.version = version;
+      }
+
+      return browser;
+    },
+  },
+
   /* Opera < 13.0 */
   {
     test: [/opera/i],
@@ -546,23 +563,6 @@ const browsersList = [
         name: 'Safari',
       };
       const version = getFirstMatch(commonVersionIdentifier, ua);
-
-      if (version) {
-        browser.version = version;
-      }
-
-      return browser;
-    },
-  },
-
-  /* Googlebot */
-  {
-    test: [/googlebot/i],
-    describe(ua) {
-      const browser = {
-        name: 'Googlebot',
-      };
-      const version = getFirstMatch(/googlebot\/(\d+(\.\d+))/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -12,6 +12,17 @@ const TYPES_LABELS = {
  */
 
 export default [
+  /* Googlebot */
+  {
+    test: [/googlebot/i],
+    describe() {
+      return {
+        type: 'bot',
+        vendor: 'Google',
+      };
+    },
+  },
+
   /* Huawei */
   {
     test: [/huawei/i],

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -2232,8 +2232,37 @@
           name: "Googlebot"
           version: "2.1"
         os: {}
-        platform: {}
+        platform:
+          type: "bot"
+          vendor: "Google"
         engine: {}
+    -
+      ua: "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+      spec:
+        browser:
+          name: "Googlebot"
+          version: "2.1"
+        os:
+          name: "Android"
+          version: "6.0.1"
+          versionName: "Marshmallow"
+        platform:
+          type: "bot"
+          vendor: "Google"
+        engine:
+          name: "Blink"
+    -
+      ua: "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36"
+      spec:
+        browser:
+          name: "Googlebot"
+          version: "2.1"
+        os: {}
+        platform:
+          type: "bot"
+          vendor: "Google"
+        engine:
+          name: "Blink"
   WeChat:
     -
       ua: "Mozilla/5.0 (iPad; U; CPU OS 9 like Mac OS X; en-us; iPad4,4) AppleWebKit/534.46 (KHTML, like Gecko) MicroMessenger/6.5.2.501 U3/1 Safari/7543.48.3"


### PR DESCRIPTION
Got two new user agent strings for the Googlebot, added tests and support for them.

`Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`

`Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36`

I had to reorder the position of the Googlebot test to prevent the platform browser being incorrectly detected as an unknown os Safari browser.

Also added new platform type "bot".