### PR TITLE
Add getEngineName and isEngine API calls

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -273,6 +273,19 @@ class Parser {
   }
 
   /**
+   * Get engines's name
+   * @return {String} Engines's name or an empty string
+   *
+   * @public
+   */
+  getEngineName(toLowerCase) {
+    if (toLowerCase) {
+      return String(this.getEngine().name).toLowerCase() || '';
+    }
+    return this.getEngine().name || '';
+  }
+
+  /**
    * Get parsed platform
    * @return {{}}
    */
@@ -435,6 +448,10 @@ class Parser {
 
   isPlatform(platformType) {
     return this.getPlatformType(true) === String(platformType).toLowerCase();
+  }
+
+  isEngine(engineName) {
+    return this.getEngineName(true) === String(engineName).toLowerCase();
   }
 
   /**

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -53,6 +53,21 @@ test('Parser.getOSVersion returns a correct result', (t) => {
   t.is(parser.getOSVersion(), '10.12.4');
 });
 
+test('Parser.parseEngine is being called when getEngine() called', (t) => {
+  const spy = sinon.spy(parser, 'parseEngine');
+  parser.getEngine();
+  t.truthy(spy.called);
+  parser.parseEngine.restore();
+});
+
+test('Parser.getEngineName gives a name of the engine', (t) => {
+  t.is(parser.getEngineName(), 'Blink');
+});
+
+test('Parser.getEngineName gives a lower-cased name of the engine', (t) => {
+  t.is(parser.getEngineName(true), 'blink');
+});
+
 test('Skip parsing shouldn\'t parse', (t) => {
   t.deepEqual((new Parser(UA, true)).getResult(), {});
 });


### PR DESCRIPTION
This patch adds the isEngine API call (and getEngineName to support it).  This will make the code cleaner in my app.