### PR TITLE
Add PlayStation 4 browser support

### DIFF
--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -555,6 +555,23 @@ const browsersList = [
     },
   },
 
+  /* PlayStation 4 */
+  {
+    test: [/playstation 4/i],
+    describe(ua) {
+      const browser = {
+        name: 'PlayStation 4',
+      };
+      const version = getFirstMatch(commonVersionIdentifier, ua);
+
+      if (version) {
+        browser.version = version;
+      }
+
+      return browser;
+    },
+  },
+
   /* Safari */
   {
     test: [/safari|applewebkit/i],

--- a/src/parser-os.js
+++ b/src/parser-os.js
@@ -154,4 +154,16 @@ export default [
       };
     },
   },
+
+  /* Playstation 4 */
+  {
+    test: [/PlayStation 4/],
+    describe(ua) {
+      const version = getFirstMatch(/PlayStation 4[/\s](\d+(\.\d+)*)/i, ua);
+      return {
+        name: 'PlayStation 4',
+        version,
+      };
+    },
+  },
 ];

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -4,6 +4,7 @@ const TYPES_LABELS = {
   tablet: 'tablet',
   mobile: 'mobile',
   desktop: 'desktop',
+  tv: 'tv',
 };
 
 /*
@@ -229,6 +230,18 @@ export default [
     describe() {
       return {
         type: TYPES_LABELS.desktop,
+      };
+    },
+  },
+
+  /* PlayStation 4 */
+  {
+    test(parser) {
+      return parser.getOSName(true) === 'playstation 4';
+    },
+    describe() {
+      return {
+        type: TYPES_LABELS.tv,
       };
     },
   },

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -2595,3 +2595,17 @@
           type: "desktop"
         engine:
           name: "Blink"
+  PlayStation 4:
+    -
+      ua: "Mozilla/5.0 (PlayStation 4 6.20) AppleWebKit/605.1.15 (KHTML, like Gecko) "
+      spec:
+        browser:
+          name: "PlayStation 4"
+        os:
+          name: "PlayStation 4"
+          version: "6.20"
+        platform:
+          type: "tv"
+        engine:
+          name: "WebKit"
+          version: "605.1.15"


### PR DESCRIPTION
Adds support for the PlayStation 4 webkit user agent string.

Wasn't sure what to do for platform since it doesn't really fit into the other categories so I added tv. If anyone has a better suggestion, willing to change that.