### PR TITLE
Add file extensions to imports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,6 +3,11 @@ extends: airbnb-base
 rules:
   no-underscore-dangle: 0
   no-void: 0
+  import/extensions:
+    - 'error'
+    - 'ignorePackages'
+    - {js: 'always'}
+
 plugins:
   - ava
   - import

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
@@ -100,7 +99,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -119,7 +117,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -303,7 +300,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -316,7 +312,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -345,7 +340,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -810,7 +806,8 @@
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -874,6 +871,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -922,13 +920,15 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
               "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -991,8 +991,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",
@@ -1009,7 +1008,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -1019,7 +1017,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -1030,15 +1027,13 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lodash": {
           "version": "4.17.11",
@@ -5170,8 +5165,7 @@
               "version": "1.1.0",
               "resolved": false,
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5351,7 +5345,6 @@
               "resolved": false,
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -5372,7 +5365,6 @@
               "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5476,7 +5468,6 @@
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5614,7 +5605,6 @@
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6231,15 +6221,13 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
@@ -6266,7 +6254,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -6285,7 +6272,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6319,7 +6305,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6329,7 +6314,6 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -6345,7 +6329,6 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -6355,7 +6338,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6365,7 +6347,6 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -6375,7 +6356,6 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -6387,7 +6367,6 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -6397,7 +6376,6 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -6409,7 +6387,6 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -6420,8 +6397,7 @@
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6430,7 +6406,6 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -6447,7 +6422,6 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -6457,7 +6431,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6469,7 +6442,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -6482,7 +6454,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6511,7 +6482,8 @@
               "version": "2.1.1",
               "resolved": false,
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6755,7 +6727,6 @@
               "resolved": false,
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -6776,7 +6747,6 @@
               "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7040,6 +7010,7 @@
               "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7088,7 +7059,8 @@
               "version": "1.0.2",
               "resolved": false,
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
@@ -7126,7 +7098,6 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -7152,7 +7123,6 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -7162,7 +7132,6 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -7179,8 +7148,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",
@@ -7197,7 +7165,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -7207,7 +7174,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -7218,8 +7184,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
@@ -7232,7 +7197,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -7253,8 +7217,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "nan": {
           "version": "2.11.0",
@@ -7268,7 +7231,6 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -7289,22 +7251,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
           "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "repeat-element": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
           "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10641,7 +10600,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11056,7 +11016,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11112,6 +11073,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11155,12 +11117,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/bowser.js
+++ b/src/bowser.js
@@ -4,7 +4,7 @@
  * MIT License | (c) Dustin Diaz 2012-2015
  * MIT License | (c) Denis Demchenko 2015-2017
  */
-import Parser from './parser';
+import Parser from './parser.js';
 
 /**
  * Bowser class.

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -23,10 +23,7 @@
  * return true/false to get the Parser know if this browser descriptor matches the UA or not.
  */
 
-import {
-  getFirstMatch,
-  getSecondMatch,
-} from './utils';
+import Utils from './utils.js';
 
 const commonVersionIdentifier = /version\/(\d+(\.?_?\d+)+)/i;
 
@@ -38,7 +35,7 @@ const browsersList = [
       const browser = {
         name: 'Googlebot',
       };
-      const version = getFirstMatch(/googlebot\/(\d+(\.\d+))/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/googlebot\/(\d+(\.\d+))/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -55,7 +52,7 @@ const browsersList = [
       const browser = {
         name: 'Opera',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:opera)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:opera)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -72,7 +69,7 @@ const browsersList = [
       const browser = {
         name: 'Opera',
       };
-      const version = getFirstMatch(/(?:opr|opios)[\s/](\S+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:opr|opios)[\s/](\S+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -87,7 +84,7 @@ const browsersList = [
       const browser = {
         name: 'Samsung Internet for Android',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:SamsungBrowser)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:SamsungBrowser)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -102,7 +99,7 @@ const browsersList = [
       const browser = {
         name: 'NAVER Whale Browser',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:whale)[\s/](\d+(?:\.\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:whale)[\s/](\d+(?:\.\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -117,7 +114,7 @@ const browsersList = [
       const browser = {
         name: 'MZ Browser',
       };
-      const version = getFirstMatch(/(?:MZBrowser)[\s/](\d+(?:\.\d+)+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:MZBrowser)[\s/](\d+(?:\.\d+)+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -132,7 +129,7 @@ const browsersList = [
       const browser = {
         name: 'Focus',
       };
-      const version = getFirstMatch(/(?:focus)[\s/](\d+(?:\.\d+)+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:focus)[\s/](\d+(?:\.\d+)+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -147,7 +144,7 @@ const browsersList = [
       const browser = {
         name: 'Swing',
       };
-      const version = getFirstMatch(/(?:swing)[\s/](\d+(?:\.\d+)+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:swing)[\s/](\d+(?:\.\d+)+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -162,7 +159,7 @@ const browsersList = [
       const browser = {
         name: 'Opera Coast',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:coast)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:coast)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -177,7 +174,7 @@ const browsersList = [
       const browser = {
         name: 'Yandex Browser',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:yabrowser)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:yabrowser)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -192,7 +189,7 @@ const browsersList = [
       const browser = {
         name: 'UC Browser',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:ucbrowser)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:ucbrowser)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -207,7 +204,7 @@ const browsersList = [
       const browser = {
         name: 'Maxthon',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:Maxthon|mxios)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:Maxthon|mxios)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -222,7 +219,7 @@ const browsersList = [
       const browser = {
         name: 'Epiphany',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:epiphany)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:epiphany)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -237,7 +234,7 @@ const browsersList = [
       const browser = {
         name: 'Puffin',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:puffin)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:puffin)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -252,7 +249,7 @@ const browsersList = [
       const browser = {
         name: 'Sleipnir',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:sleipnir)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:sleipnir)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -267,7 +264,7 @@ const browsersList = [
       const browser = {
         name: 'K-Meleon',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/(?:k-meleon)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/(?:k-meleon)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -282,7 +279,7 @@ const browsersList = [
       const browser = {
         name: 'WeChat',
       };
-      const version = getFirstMatch(/(?:micromessenger)[\s/](\d+(\.?_?\d+)+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:micromessenger)[\s/](\d+(\.?_?\d+)+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -297,7 +294,7 @@ const browsersList = [
       const browser = {
         name: 'Internet Explorer',
       };
-      const version = getFirstMatch(/(?:msie |rv:)(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/(?:msie |rv:)(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -313,7 +310,7 @@ const browsersList = [
         name: 'Microsoft Edge',
       };
 
-      const version = getSecondMatch(/edg([ea]|ios)\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getSecondMatch(/edg([ea]|ios)\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -328,7 +325,7 @@ const browsersList = [
       const browser = {
         name: 'Vivaldi',
       };
-      const version = getFirstMatch(/vivaldi\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/vivaldi\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -343,7 +340,7 @@ const browsersList = [
       const browser = {
         name: 'SeaMonkey',
       };
-      const version = getFirstMatch(/seamonkey\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/seamonkey\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -359,7 +356,7 @@ const browsersList = [
         name: 'Sailfish',
       };
 
-      const version = getFirstMatch(/sailfish\s?browser\/(\d+(\.\d+)?)/i, ua);
+      const version = Utils.getFirstMatch(/sailfish\s?browser\/(\d+(\.\d+)?)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -374,7 +371,7 @@ const browsersList = [
       const browser = {
         name: 'Amazon Silk',
       };
-      const version = getFirstMatch(/silk\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/silk\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -389,7 +386,7 @@ const browsersList = [
       const browser = {
         name: 'PhantomJS',
       };
-      const version = getFirstMatch(/phantomjs\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/phantomjs\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -404,7 +401,7 @@ const browsersList = [
       const browser = {
         name: 'SlimerJS',
       };
-      const version = getFirstMatch(/slimerjs\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/slimerjs\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -419,7 +416,7 @@ const browsersList = [
       const browser = {
         name: 'BlackBerry',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/blackberry[\d]+\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/blackberry[\d]+\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -434,7 +431,7 @@ const browsersList = [
       const browser = {
         name: 'WebOS Browser',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua) || getFirstMatch(/w(?:eb)?[o0]sbrowser\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua) || Utils.getFirstMatch(/w(?:eb)?[o0]sbrowser\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -449,7 +446,7 @@ const browsersList = [
       const browser = {
         name: 'Bada',
       };
-      const version = getFirstMatch(/dolfin\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/dolfin\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -464,7 +461,7 @@ const browsersList = [
       const browser = {
         name: 'Tizen',
       };
-      const version = getFirstMatch(/(?:tizen\s?)?browser\/(\d+(\.?_?\d+)+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:tizen\s?)?browser\/(\d+(\.?_?\d+)+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -479,7 +476,7 @@ const browsersList = [
       const browser = {
         name: 'QupZilla',
       };
-      const version = getFirstMatch(/(?:qupzilla)[\s/](\d+(\.?_?\d+)+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:qupzilla)[\s/](\d+(\.?_?\d+)+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -494,7 +491,7 @@ const browsersList = [
       const browser = {
         name: 'Firefox',
       };
-      const version = getFirstMatch(/(?:firefox|iceweasel|fxios)[\s/](\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/(?:firefox|iceweasel|fxios)[\s/](\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -509,7 +506,7 @@ const browsersList = [
       const browser = {
         name: 'Chromium',
       };
-      const version = getFirstMatch(/(?:chromium)[\s/](\d+(\.?_?\d+)+)/i, ua) || getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(/(?:chromium)[\s/](\d+(\.?_?\d+)+)/i, ua) || Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -524,7 +521,7 @@ const browsersList = [
       const browser = {
         name: 'Chrome',
       };
-      const version = getFirstMatch(/(?:chrome|crios|crmo)\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/(?:chrome|crios|crmo)\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         browser.version = version;
@@ -545,7 +542,7 @@ const browsersList = [
       const browser = {
         name: 'Android Browser',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -562,7 +559,7 @@ const browsersList = [
       const browser = {
         name: 'Safari',
       };
-      const version = getFirstMatch(commonVersionIdentifier, ua);
+      const version = Utils.getFirstMatch(commonVersionIdentifier, ua);
 
       if (version) {
         browser.version = version;
@@ -577,8 +574,8 @@ const browsersList = [
     test: [/.*/i],
     describe(ua) {
       return {
-        name: getFirstMatch(/^(.*)\/(.*) /, ua),
-        version: getSecondMatch(/^(.*)\/(.*) /, ua),
+        name: Utils.getFirstMatch(/^(.*)\/(.*) /, ua),
+        version: Utils.getSecondMatch(/^(.*)\/(.*) /, ua),
       };
     },
   },

--- a/src/parser-engines.js
+++ b/src/parser-engines.js
@@ -1,4 +1,4 @@
-import { getFirstMatch } from './utils';
+import Utils from './utils.js';
 
 /*
  * More specific goes first
@@ -10,7 +10,7 @@ export default [
       return parser.getBrowserName(true) === 'microsoft edge';
     },
     describe(ua) {
-      const version = getFirstMatch(/edge\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/edge\/(\d+(\.?_?\d+)+)/i, ua);
       return {
         name: 'EdgeHTML',
         version,
@@ -26,7 +26,7 @@ export default [
         name: 'Trident',
       };
 
-      const version = getFirstMatch(/trident\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/trident\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         engine.version = version;
@@ -46,7 +46,7 @@ export default [
         name: 'Presto',
       };
 
-      const version = getFirstMatch(/presto\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/presto\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         engine.version = version;
@@ -68,7 +68,7 @@ export default [
         name: 'Gecko',
       };
 
-      const version = getFirstMatch(/gecko\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/gecko\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         engine.version = version;
@@ -96,7 +96,7 @@ export default [
         name: 'WebKit',
       };
 
-      const version = getFirstMatch(/webkit\/(\d+(\.?_?\d+)+)/i, ua);
+      const version = Utils.getFirstMatch(/webkit\/(\d+(\.?_?\d+)+)/i, ua);
 
       if (version) {
         engine.version = version;

--- a/src/parser-os.js
+++ b/src/parser-os.js
@@ -1,15 +1,11 @@
-import {
-  getFirstMatch,
-  getWindowsVersionName,
-  getAndroidVersionName,
-} from './utils';
+import Utils from './utils.js';
 
 export default [
   /* Windows Phone */
   {
     test: [/windows phone/i],
     describe(ua) {
-      const version = getFirstMatch(/windows phone (?:os)?\s?(\d+(\.\d+)*)/i, ua);
+      const version = Utils.getFirstMatch(/windows phone (?:os)?\s?(\d+(\.\d+)*)/i, ua);
       return {
         name: 'Windows Phone',
         version,
@@ -21,8 +17,8 @@ export default [
   {
     test: [/windows/i],
     describe(ua) {
-      const version = getFirstMatch(/Windows ((NT|XP)( \d\d?.\d)?)/i, ua);
-      const versionName = getWindowsVersionName(version);
+      const version = Utils.getFirstMatch(/Windows ((NT|XP)( \d\d?.\d)?)/i, ua);
+      const versionName = Utils.getWindowsVersionName(version);
 
       return {
         name: 'Windows',
@@ -36,7 +32,7 @@ export default [
   {
     test: [/macintosh/i],
     describe(ua) {
-      const version = getFirstMatch(/mac os x (\d+(\.?_?\d+)+)/i, ua).replace(/[_\s]/g, '.');
+      const version = Utils.getFirstMatch(/mac os x (\d+(\.?_?\d+)+)/i, ua).replace(/[_\s]/g, '.');
       return {
         name: 'macOS',
         version,
@@ -48,7 +44,7 @@ export default [
   {
     test: [/(ipod|iphone|ipad)/i],
     describe(ua) {
-      const version = getFirstMatch(/os (\d+([_\s]\d+)*) like mac os x/i, ua).replace(/[_\s]/g, '.');
+      const version = Utils.getFirstMatch(/os (\d+([_\s]\d+)*) like mac os x/i, ua).replace(/[_\s]/g, '.');
 
       return {
         name: 'iOS',
@@ -65,8 +61,8 @@ export default [
       return notLikeAndroid && butAndroid;
     },
     describe(ua) {
-      const version = getFirstMatch(/android[\s/-](\d+(\.\d+)*)/i, ua);
-      const versionName = getAndroidVersionName(version);
+      const version = Utils.getFirstMatch(/android[\s/-](\d+(\.\d+)*)/i, ua);
+      const versionName = Utils.getAndroidVersionName(version);
       const os = {
         name: 'Android',
         version,
@@ -82,7 +78,7 @@ export default [
   {
     test: [/(web|hpw)[o0]s/i],
     describe(ua) {
-      const version = getFirstMatch(/(?:web|hpw)[o0]s\/(\d+(\.\d+)*)/i, ua);
+      const version = Utils.getFirstMatch(/(?:web|hpw)[o0]s\/(\d+(\.\d+)*)/i, ua);
       const os = {
         name: 'WebOS',
       };
@@ -98,9 +94,9 @@ export default [
   {
     test: [/blackberry|\bbb\d+/i, /rim\stablet/i],
     describe(ua) {
-      const version = getFirstMatch(/rim\stablet\sos\s(\d+(\.\d+)*)/i, ua)
-        || getFirstMatch(/blackberry\d+\/(\d+([_\s]\d+)*)/i, ua)
-        || getFirstMatch(/\bbb(\d+)/i, ua);
+      const version = Utils.getFirstMatch(/rim\stablet\sos\s(\d+(\.\d+)*)/i, ua)
+        || Utils.getFirstMatch(/blackberry\d+\/(\d+([_\s]\d+)*)/i, ua)
+        || Utils.getFirstMatch(/\bbb(\d+)/i, ua);
 
       return {
         name: 'BlackBerry',
@@ -113,7 +109,7 @@ export default [
   {
     test: [/bada/i],
     describe(ua) {
-      const version = getFirstMatch(/bada\/(\d+(\.\d+)*)/i, ua);
+      const version = Utils.getFirstMatch(/bada\/(\d+(\.\d+)*)/i, ua);
 
       return {
         name: 'Bada',
@@ -126,7 +122,7 @@ export default [
   {
     test: [/tizen/i],
     describe(ua) {
-      const version = getFirstMatch(/tizen[/\s](\d+(\.\d+)*)/i, ua);
+      const version = Utils.getFirstMatch(/tizen[/\s](\d+(\.\d+)*)/i, ua);
 
       return {
         name: 'Tizen',

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -1,4 +1,4 @@
-import { getFirstMatch } from './utils';
+import Utils from './utils.js';
 
 const TYPES_LABELS = {
   tablet: 'tablet',
@@ -27,7 +27,7 @@ export default [
   {
     test: [/huawei/i],
     describe(ua) {
-      const model = getFirstMatch(/(can-l01)/i, ua) && 'Nova';
+      const model = Utils.getFirstMatch(/(can-l01)/i, ua) && 'Nova';
       const platform = {
         type: TYPES_LABELS.mobile,
         vendor: 'Huawei',
@@ -103,7 +103,7 @@ export default [
       return iDevice && !likeIDevice;
     },
     describe(ua) {
-      const model = getFirstMatch(/(ipod|iphone)/i, ua);
+      const model = Utils.getFirstMatch(/(ipod|iphone)/i, ua);
       return {
         type: TYPES_LABELS.mobile,
         vendor: 'Apple',

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,8 +1,8 @@
-import browserParsersList from './parser-browsers';
-import osParsersList from './parser-os';
-import platformParsersList from './parser-platforms';
-import enginesParsersList from './parser-engines';
-import { compareVersions } from './utils';
+import browserParsersList from './parser-browsers.js';
+import osParsersList from './parser-os.js';
+import platformParsersList from './parser-platforms.js';
+import enginesParsersList from './parser-engines.js';
+import Utils from './utils.js';
 
 /**
  * The main class that arranges the whole parsing process.
@@ -438,7 +438,7 @@ class Parser {
     }
 
     return expectedResults.indexOf(
-      compareVersions(currentBrowserVersion, comparableVersion, isLoose),
+      Utils.compareVersions(currentBrowserVersion, comparableVersion, isLoose),
     ) > -1;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-class Utils {
+export default class Utils {
   /**
    * Get first matched item for a string
    * @param {RegExp} regexp
@@ -188,5 +188,3 @@ class Utils {
     return result;
   }
 }
-
-module.exports = Utils;


### PR DESCRIPTION
In order to support loading Bowser directly in the browser without transpilation this PR :
* Adds _.js_ file extensions to imports.
* Adds ES6 style export to utils and changes related utils imports
* Updates eslint rule for import extensions

Unit tests appear to need no changes as functionality is the same.

**Some thoughts**
As utils.js is a class collection of static functions it might be better the split them into a set of separate exports. This would mean imports could look like they are in the current master branch:
```Javascript
import { getFirstMatch, getSecondMatch, } from './utils.js';
```
rather than importing the whole of Utils.