### PR TITLE
Update the regexp for generic browsers

### DIFF
--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -590,13 +590,13 @@ const browsersList = [
   {
     test: [/.*/i],
     describe(ua) {
-	  /* Here we try to make sure that there are explicit details about the device 
-	   * in order to decide what regexp exactly we want to apply 
-	   * (as there is a specific decision based on that conclusion)
-	   */
-	  const regexpWithoutDeviceSpec = /^(.*)\/(.*) /;
-	  const regexpWithDeviceSpec = /^(.*)\/(.*)[ \t]\((.*)/;
-	  const hasDeviceSpec = ua.search('\\(') !== -1;
+      /* Here we try to make sure that there are explicit details about the device
+       * in order to decide what regexp exactly we want to apply
+       * (as there is a specific decision based on that conclusion)
+       */
+      const regexpWithoutDeviceSpec = /^(.*)\/(.*) /;
+      const regexpWithDeviceSpec = /^(.*)\/(.*)[ \t]\((.*)/;
+      const hasDeviceSpec = ua.search('\\(') !== -1;
       const regexp = hasDeviceSpec ? regexpWithoutDeviceSpec : regexpWithDeviceSpec;
       return {
         name: Utils.getFirstMatch(regexp, ua),

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -590,9 +590,10 @@ const browsersList = [
   {
     test: [/.*/i],
     describe(ua) {
+	  const regexp = ua.search("\\(") == -1 ? /^(.*)\/(.*) / : /^(.*)\/(.*)\((.*) /
       return {
-        name: Utils.getFirstMatch(/^(.*)\/(.*)\((.*) /, ua),
-        version: Utils.getSecondMatch(/^(.*)\/(.*)\((.*) /, ua),
+        name: Utils.getFirstMatch(regexp, ua),
+        version: Utils.getSecondMatch(regexp, ua),
       };
     },
   },

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -590,7 +590,10 @@ const browsersList = [
   {
     test: [/.*/i],
     describe(ua) {
-	  // Define the regexp depending if the ua has device specifications
+	  /* Here we try to make sure that there are explicit details about the device 
+	   * in order to decide what regexp exactly we want to apply 
+	   * (as there is a specific decision based on that conclusion)
+	   */
 	  const regexpWithoutParenthesis = /^(.*)\/(.*) /;
 	  const regexpWithParenthesis = /^(.*)\/(.*)[ \t]\((.*)/;
 	  const hasDeviceSpec = ua.search('\\(') !== -1;

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -590,7 +590,7 @@ const browsersList = [
   {
     test: [/.*/i],
     describe(ua) {
-	  const regexp = ua.search("\\(") == -1 ? /^(.*)\/(.*) / : /^(.*)\/(.*)\((.*) /
+      const regexp = ua.search('\\(') === -1 ? /^(.*)\/(.*) / : /^(.*)\/(.*)[ \t]\((.*)/;
       return {
         name: Utils.getFirstMatch(regexp, ua),
         version: Utils.getSecondMatch(regexp, ua),

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -590,7 +590,11 @@ const browsersList = [
   {
     test: [/.*/i],
     describe(ua) {
-      const regexp = ua.search('\\(') === -1 ? /^(.*)\/(.*) / : /^(.*)\/(.*)[ \t]\((.*)/;
+	  // Define the regexp depending if the ua has device specifications
+	  const regexpWithoutParenthesis = /^(.*)\/(.*) /;
+	  const regexpWithParenthesis = /^(.*)\/(.*)[ \t]\((.*)/;
+	  const hasDeviceSpec = ua.search('\\(') !== -1;
+      const regexp = hasDeviceSpec ? regexpWithoutParenthesis : regexpWithParenthesis;
       return {
         name: Utils.getFirstMatch(regexp, ua),
         version: Utils.getSecondMatch(regexp, ua),

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -591,8 +591,8 @@ const browsersList = [
     test: [/.*/i],
     describe(ua) {
       return {
-        name: Utils.getFirstMatch(/^(.*)\/(.*) /, ua),
-        version: Utils.getSecondMatch(/^(.*)\/(.*) /, ua),
+        name: Utils.getFirstMatch(/^(.*)\/(.*)\((.*) /, ua),
+        version: Utils.getSecondMatch(/^(.*)\/(.*)\((.*) /, ua),
       };
     },
   },

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -594,10 +594,10 @@ const browsersList = [
 	   * in order to decide what regexp exactly we want to apply 
 	   * (as there is a specific decision based on that conclusion)
 	   */
-	  const regexpWithoutParenthesis = /^(.*)\/(.*) /;
-	  const regexpWithParenthesis = /^(.*)\/(.*)[ \t]\((.*)/;
+	  const regexpWithoutDeviceSpec = /^(.*)\/(.*) /;
+	  const regexpWithDeviceSpec = /^(.*)\/(.*)[ \t]\((.*)/;
 	  const hasDeviceSpec = ua.search('\\(') !== -1;
-      const regexp = hasDeviceSpec ? regexpWithoutParenthesis : regexpWithParenthesis;
+      const regexp = hasDeviceSpec ? regexpWithoutDeviceSpec : regexpWithDeviceSpec;
       return {
         name: Utils.getFirstMatch(regexp, ua),
         version: Utils.getSecondMatch(regexp, ua),

--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -597,7 +597,7 @@ const browsersList = [
       const regexpWithoutDeviceSpec = /^(.*)\/(.*) /;
       const regexpWithDeviceSpec = /^(.*)\/(.*)[ \t]\((.*)/;
       const hasDeviceSpec = ua.search('\\(') !== -1;
-      const regexp = hasDeviceSpec ? regexpWithoutDeviceSpec : regexpWithDeviceSpec;
+      const regexp = hasDeviceSpec ? regexpWithDeviceSpec : regexpWithoutDeviceSpec;
       return {
         name: Utils.getFirstMatch(regexp, ua),
         version: Utils.getSecondMatch(regexp, ua),

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -2217,6 +2217,15 @@
           name: "Blink"
   Generic:
     -
+      ua: "Generic/2.15 libww"
+      spec:
+        browser:
+          name: "Generic"
+          version: "2.15"
+        os: {}
+        platform: {}
+        engine: {}
+    -
       ua: "Generic/2.15 (Macintosh; Intel Mac OS X 10_6_8)"
       spec:
         browser:

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -2231,8 +2231,12 @@
         browser:
           name: "Generic"
           version: "2.15"
-        os: {}
-        platform: {}
+        os:
+          name: "macOS"
+          version: "10.6.8"
+        platform:
+          type: "desktop"
+          vendor: "Apple"
         engine: {}
   Googlebot:
     -

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -2217,7 +2217,7 @@
           name: "Blink"
   Generic:
     -
-      ua: "Generic/2.15 libww"
+      ua: "Generic/2.15 (Macintosh; Intel Mac OS X 10_6_8)"
       spec:
         browser:
           name: "Generic"


### PR DESCRIPTION
Hi @lancedikson,

First of all, thanks for the awesome module!

Second, I was trying to set a custom user-agent for my iOS app `iOSApp/3.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X)` and right now the result is `browser.name = iOSApp` and `browser.version = 3.0 (iPad; CPU iPhone OS 12_1_4 like Mac OS`. 

I noticed that this is happening because of the regexp on `parser-browser.js:594-595`, so I came up with a slightly different regexp to get the correct data. With this, I was able to get `browser.name = iOSApp` and `browser.version = 3.0`. 

```
Browser name: iOSApp
Browser version: 3.0
OS name: iOS
OS version: 12.1.4
Platform type: mobile
Platform vendor: Apple
Engine name: undefined
```

I hope this could help many other people as well :)