### PR TITLE
Add constant output so that users can quickly get all types

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -5,6 +5,12 @@
  * MIT License | (c) Denis Demchenko 2015-2017
  */
 import Parser from './parser.js';
+import {
+  BROWSER_MAP,
+  ENGINE_MAP,
+  OS_MAP,
+  PLATFORMS_MAP,
+} from './constants.js';
 
 /**
  * Bowser class.
@@ -46,5 +52,10 @@ class Bowser {
     return (new Parser(UA)).getResult();
   }
 }
+
+Bowser.BROWSER_MAP = BROWSER_MAP;
+Bowser.ENGINE_MAP = ENGINE_MAP;
+Bowser.OS_MAP = OS_MAP;
+Bowser.PLATFORMS_MAP = PLATFORMS_MAP;
 
 export default Bowser;

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,3 +36,71 @@ export const BROWSER_ALIASES_MAP = {
   WeChat: 'wechat',
   'Yandex Browser': 'yandex',
 };
+
+export const BROWSER_MAP = {
+  amazon_silk: 'Amazon Silk',
+  android: 'Android Browser',
+  bada: 'Bada',
+  blackberry: 'BlackBerry',
+  chrome: 'Chrome',
+  chromium: 'Chromium',
+  epiphany: 'Epiphany',
+  firefox: 'Firefox',
+  focus: 'Focus',
+  generic: 'Generic',
+  googlebot: 'Googlebot',
+  ie: 'Internet Explorer',
+  k_meleon: 'K-Meleon',
+  maxthon: 'Maxthon',
+  edge: 'Microsoft Edge',
+  mz: 'MZ Browser',
+  naver: 'NAVER Whale Browser',
+  opera: 'Opera',
+  opera_coast: 'Opera Coast',
+  phantomjs: 'PhantomJS',
+  puffin: 'Puffin',
+  qupzilla: 'QupZilla',
+  safari: 'Safari',
+  sailfish: 'Sailfish',
+  samsung_internet: 'Samsung Internet for Android',
+  seamonkey: 'SeaMonkey',
+  sleipnir: 'Sleipnir',
+  swing: 'Swing',
+  tizen: 'Tizen',
+  uc: 'UC Browser',
+  vivaldi: 'Vivaldi',
+  webos: 'WebOS Browser',
+  wechat: 'WeChat',
+  yandex: 'Yandex Browser',
+};
+
+export const PLATFORMS_MAP = {
+  tablet: 'tablet',
+  mobile: 'mobile',
+  desktop: 'desktop',
+  tv: 'tv',
+};
+
+export const OS_MAP = {
+  WindowsPhone: 'Windows Phone',
+  Windows: 'Windows',
+  MacOS: 'macOS',
+  iOS: 'iOS',
+  Android: 'Android',
+  WebOS: 'WebOS',
+  BlackBerry: 'BlackBerry',
+  Bada: 'Bada',
+  Tizen: 'Tizen',
+  Linux: 'Linux',
+  ChromeOS: 'Chrome OS',
+  PlayStation4: 'PlayStation 4',
+};
+
+export const ENGINE_MAP = {
+  EdgeHTML: 'EdgeHTML',
+  Blink: 'Blink',
+  Trident: 'Trident',
+  Presto: 'Presto',
+  Gecko: 'Gecko',
+  WebKit: 'WebKit',
+};

--- a/src/parser-engines.js
+++ b/src/parser-engines.js
@@ -1,4 +1,5 @@
 import Utils from './utils.js';
+import { ENGINE_MAP } from './constants.js';
 
 /*
  * More specific goes first
@@ -15,7 +16,7 @@ export default [
       // return blink if it's blink-based one
       if (isBlinkBased) {
         return {
-          name: 'Blink',
+          name: ENGINE_MAP.Blink,
         };
       }
 
@@ -23,7 +24,7 @@ export default [
       const version = Utils.getFirstMatch(/edge\/(\d+(\.?_?\d+)+)/i, ua);
 
       return {
-        name: 'EdgeHTML',
+        name: ENGINE_MAP.EdgeHTML,
         version,
       };
     },
@@ -34,7 +35,7 @@ export default [
     test: [/trident/i],
     describe(ua) {
       const engine = {
-        name: 'Trident',
+        name: ENGINE_MAP.Trident,
       };
 
       const version = Utils.getFirstMatch(/trident\/(\d+(\.?_?\d+)+)/i, ua);
@@ -54,7 +55,7 @@ export default [
     },
     describe(ua) {
       const engine = {
-        name: 'Presto',
+        name: ENGINE_MAP.Presto,
       };
 
       const version = Utils.getFirstMatch(/presto\/(\d+(\.?_?\d+)+)/i, ua);
@@ -76,7 +77,7 @@ export default [
     },
     describe(ua) {
       const engine = {
-        name: 'Gecko',
+        name: ENGINE_MAP.Gecko,
       };
 
       const version = Utils.getFirstMatch(/gecko\/(\d+(\.?_?\d+)+)/i, ua);
@@ -94,7 +95,7 @@ export default [
     test: [/(apple)?webkit\/537\.36/i],
     describe() {
       return {
-        name: 'Blink',
+        name: ENGINE_MAP.Blink,
       };
     },
   },
@@ -104,7 +105,7 @@ export default [
     test: [/(apple)?webkit/i],
     describe(ua) {
       const engine = {
-        name: 'WebKit',
+        name: ENGINE_MAP.WebKit,
       };
 
       const version = Utils.getFirstMatch(/webkit\/(\d+(\.?_?\d+)+)/i, ua);

--- a/src/parser-os.js
+++ b/src/parser-os.js
@@ -1,4 +1,5 @@
 import Utils from './utils.js';
+import { OS_MAP } from './constants.js';
 
 export default [
   /* Windows Phone */
@@ -7,7 +8,7 @@ export default [
     describe(ua) {
       const version = Utils.getFirstMatch(/windows phone (?:os)?\s?(\d+(\.\d+)*)/i, ua);
       return {
-        name: 'Windows Phone',
+        name: OS_MAP.WindowsPhone,
         version,
       };
     },
@@ -21,7 +22,7 @@ export default [
       const versionName = Utils.getWindowsVersionName(version);
 
       return {
-        name: 'Windows',
+        name: OS_MAP.Windows,
         version,
         versionName,
       };
@@ -34,7 +35,7 @@ export default [
     describe(ua) {
       const version = Utils.getFirstMatch(/mac os x (\d+(\.?_?\d+)+)/i, ua).replace(/[_\s]/g, '.');
       return {
-        name: 'macOS',
+        name: OS_MAP.MacOS,
         version,
       };
     },
@@ -47,7 +48,7 @@ export default [
       const version = Utils.getFirstMatch(/os (\d+([_\s]\d+)*) like mac os x/i, ua).replace(/[_\s]/g, '.');
 
       return {
-        name: 'iOS',
+        name: OS_MAP.iOS,
         version,
       };
     },
@@ -64,7 +65,7 @@ export default [
       const version = Utils.getFirstMatch(/android[\s/-](\d+(\.\d+)*)/i, ua);
       const versionName = Utils.getAndroidVersionName(version);
       const os = {
-        name: 'Android',
+        name: OS_MAP.Android,
         version,
       };
       if (versionName) {
@@ -80,7 +81,7 @@ export default [
     describe(ua) {
       const version = Utils.getFirstMatch(/(?:web|hpw)[o0]s\/(\d+(\.\d+)*)/i, ua);
       const os = {
-        name: 'WebOS',
+        name: OS_MAP.WebOS,
       };
 
       if (version && version.length) {
@@ -99,7 +100,7 @@ export default [
         || Utils.getFirstMatch(/\bbb(\d+)/i, ua);
 
       return {
-        name: 'BlackBerry',
+        name: OS_MAP.BlackBerry,
         version,
       };
     },
@@ -112,7 +113,7 @@ export default [
       const version = Utils.getFirstMatch(/bada\/(\d+(\.\d+)*)/i, ua);
 
       return {
-        name: 'Bada',
+        name: OS_MAP.Bada,
         version,
       };
     },
@@ -125,7 +126,7 @@ export default [
       const version = Utils.getFirstMatch(/tizen[/\s](\d+(\.\d+)*)/i, ua);
 
       return {
-        name: 'Tizen',
+        name: OS_MAP.Tizen,
         version,
       };
     },
@@ -136,7 +137,7 @@ export default [
     test: [/linux/i],
     describe() {
       return {
-        name: 'Linux',
+        name: OS_MAP.Linux,
       };
     },
   },
@@ -146,7 +147,7 @@ export default [
     test: [/CrOS/],
     describe() {
       return {
-        name: 'Chrome OS',
+        name: OS_MAP.ChromeOS,
       };
     },
   },
@@ -157,7 +158,7 @@ export default [
     describe(ua) {
       const version = Utils.getFirstMatch(/PlayStation 4[/\s](\d+(\.\d+)*)/i, ua);
       return {
-        name: 'PlayStation 4',
+        name: OS_MAP.PlayStation4,
         version,
       };
     },

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -1,11 +1,5 @@
 import Utils from './utils.js';
-
-const TYPES_LABELS = {
-  tablet: 'tablet',
-  mobile: 'mobile',
-  desktop: 'desktop',
-  tv: 'tv',
-};
+import { PLATFORMS_MAP } from './constants.js';
 
 /*
  * Tablets go first since usually they have more specific
@@ -30,7 +24,7 @@ export default [
     describe(ua) {
       const model = Utils.getFirstMatch(/(can-l01)/i, ua) && 'Nova';
       const platform = {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
         vendor: 'Huawei',
       };
       if (model) {
@@ -45,7 +39,7 @@ export default [
     test: [/nexus\s*(?:7|8|9|10).*/i],
     describe() {
       return {
-        type: TYPES_LABELS.tablet,
+        type: PLATFORMS_MAP.tablet,
         vendor: 'Nexus',
       };
     },
@@ -56,7 +50,7 @@ export default [
     test: [/ipad/i],
     describe() {
       return {
-        type: TYPES_LABELS.tablet,
+        type: PLATFORMS_MAP.tablet,
         vendor: 'Apple',
         model: 'iPad',
       };
@@ -68,7 +62,7 @@ export default [
     test: [/kftt build/i],
     describe() {
       return {
-        type: TYPES_LABELS.tablet,
+        type: PLATFORMS_MAP.tablet,
         vendor: 'Amazon',
         model: 'Kindle Fire HD 7',
       };
@@ -80,7 +74,7 @@ export default [
     test: [/silk/i],
     describe() {
       return {
-        type: TYPES_LABELS.tablet,
+        type: PLATFORMS_MAP.tablet,
         vendor: 'Amazon',
       };
     },
@@ -91,7 +85,7 @@ export default [
     test: [/tablet/i],
     describe() {
       return {
-        type: TYPES_LABELS.tablet,
+        type: PLATFORMS_MAP.tablet,
       };
     },
   },
@@ -106,7 +100,7 @@ export default [
     describe(ua) {
       const model = Utils.getFirstMatch(/(ipod|iphone)/i, ua);
       return {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
         vendor: 'Apple',
         model,
       };
@@ -118,7 +112,7 @@ export default [
     test: [/nexus\s*[0-6].*/i, /galaxy nexus/i],
     describe() {
       return {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
         vendor: 'Nexus',
       };
     },
@@ -129,7 +123,7 @@ export default [
     test: [/[^-]mobi/i],
     describe() {
       return {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
       };
     },
   },
@@ -141,7 +135,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
         vendor: 'BlackBerry',
       };
     },
@@ -154,7 +148,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
       };
     },
   },
@@ -166,7 +160,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
         vendor: 'Microsoft',
       };
     },
@@ -180,7 +174,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.tablet,
+        type: PLATFORMS_MAP.tablet,
       };
     },
   },
@@ -192,7 +186,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.mobile,
+        type: PLATFORMS_MAP.mobile,
       };
     },
   },
@@ -204,7 +198,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.desktop,
+        type: PLATFORMS_MAP.desktop,
         vendor: 'Apple',
       };
     },
@@ -217,7 +211,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.desktop,
+        type: PLATFORMS_MAP.desktop,
       };
     },
   },
@@ -229,7 +223,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.desktop,
+        type: PLATFORMS_MAP.desktop,
       };
     },
   },
@@ -241,7 +235,7 @@ export default [
     },
     describe() {
       return {
-        type: TYPES_LABELS.tv,
+        type: PLATFORMS_MAP.tv,
       };
     },
   },

--- a/src/parser.js
+++ b/src/parser.js
@@ -409,15 +409,14 @@ class Parser {
    * @returns {boolean}
    */
   isBrowser(browserName, includingAlias = false) {
-    const defaultBrowserName = this.getBrowserName();
-    const possibleNames = [defaultBrowserName.toLowerCase()];
-    const alias = Utils.getBrowserAlias(defaultBrowserName);
+    const defaultBrowserName = this.getBrowserName().toLowerCase();
+    let browserNameLower = browserName.toLowerCase();
+    const alias = Utils.getBrowserTypeByAlias(browserNameLower);
 
-    if (includingAlias && typeof alias !== 'undefined') {
-      possibleNames.push(alias.toLowerCase());
+    if (includingAlias && alias) {
+      browserNameLower = alias.toLowerCase();
     }
-
-    return possibleNames.indexOf(browserName.toLowerCase()) !== -1;
+    return browserNameLower === defaultBrowserName;
   }
 
   compareVersion(version) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { BROWSER_ALIASES_MAP } from './constants.js';
+import { BROWSER_MAP, BROWSER_ALIASES_MAP } from './constants.js';
 
 export default class Utils {
   /**
@@ -201,5 +201,18 @@ export default class Utils {
    */
   static getBrowserAlias(browserName) {
     return BROWSER_ALIASES_MAP[browserName];
+  }
+
+  /**
+   * Get short version/alias for a browser name
+   *
+   * @example
+   *   getBrowserAlias('edge') // Microsoft Edge
+   *
+   * @param  {string} browserName
+   * @return {string}
+   */
+  static getBrowserTypeByAlias(browserAlia) {
+    return BROWSER_MAP[browserAlia] || '';
   }
 }

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import sinon from 'sinon';
 import Parser from '../../src/parser';
+import Bowser from '../../src/bowser';
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 OPR/43.0.2442.1165';
 const parser = new Parser(UA, true);
@@ -162,6 +163,12 @@ test('Parser.is should pass', (t) => {
   t.is(parser.is('opera'), true);
   t.is(parser.is('desktop'), true);
   t.is(parser.is('macos'), true);
+});
+
+test('Parser.is using constants should pass', (t) => {
+  t.is(parser.is(Bowser.BROWSER_MAP.opera), true);
+  t.is(parser.is(Bowser.PLATFORMS_MAP.desktop), true);
+  t.is(parser.is(Bowser.OS_MAP.MacOS), true);
 });
 
 test('Parser.some should pass', (t) => {


### PR DESCRIPTION
Now you can use it like this, and all tests have passed.
```javascript
import Bowser from 'bowser';

const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 OPR/43.0.2442.1165';

const parser = new Parser(UA, true);

parser.is(Bowser.OS_MAP.MacOS) === true
```

Most of the time when using bowser, we need to query alias mapping many times, which can solve this problem very well and make use of IDE's automatic completion.

It's time to say goodbye to the alias.