### PR TITLE
adding detection for Roku OS

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,7 @@ export const BROWSER_ALIASES_MAP = {
   'WebOS Browser': 'webos',
   WeChat: 'wechat',
   'Yandex Browser': 'yandex',
+  Roku: 'roku',
 };
 
 export const BROWSER_MAP = {
@@ -94,6 +95,7 @@ export const OS_MAP = {
   Linux: 'Linux',
   ChromeOS: 'Chrome OS',
   PlayStation4: 'PlayStation 4',
+  Roku: 'Roku',
 };
 
 export const ENGINE_MAP = {

--- a/src/parser-os.js
+++ b/src/parser-os.js
@@ -2,6 +2,18 @@ import Utils from './utils.js';
 import { OS_MAP } from './constants.js';
 
 export default [
+  /* Roku */
+  {
+    test: [/Roku\/DVP/],
+    describe(ua) {
+      const version = Utils.getFirstMatch(/Roku\/DVP-(\d+\.\d+)/i, ua);
+      return {
+        name: OS_MAP.Roku,
+        version,
+      };
+    },
+  },
+
   /* Windows Phone */
   {
     test: [/windows phone/i],

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -239,4 +239,16 @@ export default [
       };
     },
   },
+
+  /* Roku */
+  {
+    test(parser) {
+      return parser.getOSName(true) === 'roku';
+    },
+    describe() {
+      return {
+        type: PLATFORMS_MAP.tv,
+      };
+    },
+  },
 ];

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -308,6 +308,18 @@
           type: "mobile"
         engine:
           name: "Blink"
+    - ua: "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36 Roku/DVP-7.53 (147.53E04068A)"
+      spec:
+        browser:
+          name: "Chrome"
+          version: "60.0.3112.113"
+        os:
+          name: "Roku"
+          version: "7.53"
+        platform:
+          type: "tv"
+        engine:
+          name: "Blink"
   Amazon Silk:
     -
       ua: "Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.4 Mobile Safari/535.19 Silk-Accelerated=true"
@@ -2666,3 +2678,16 @@
         engine:
           name: "WebKit"
           version: "605.1.15"
+  Roku:
+    -
+      ua: "Roku/DVP-9.0 (047.00E09044A)"
+      spec:
+        browser:
+          name: "Roku"
+          version: "DVP-9.0"
+        os:
+          name: "Roku"
+          version: "9.0"
+        platform:
+          type: "tv"
+        engine: {}


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Roku#Software

examples: http://www.webapps-online.com/online-tools/user-agent-strings/dv/brand798903/roku-dvp

note: The reason I added the test for Roku before all other tests is that Roku user agents might contain other tokens (like Windows), but Roku is still Roku.