### PR TITLE
Update package.json to point to "types"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     }
   ],
   "main": "es5.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lancedikson/bowser.git"


### PR DESCRIPTION
> Also note that if your main declaration file is named index.d.ts and lives at the root of the package (next to index.js) you do not need to mark the "types" property, though it is advisable to do so.

