### PR TITLE
Add 'module' field to manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     }
   ],
   "main": "es5.js",
+  "module": "src/bowser.js",
   "types": "index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The 'module' field is used by bundlers such as rollup and webpack to determine the entrypoint for a package. Conventionally 'module' is used for the ES6 entrypoint, and 'main' is used for the CommonJS entrypoint.

Adding a 'module' field allows importing bowser as an ES6 module directly, rather than using a package-relative path to the ES6 entrypoint (e.g. `bowser/src/bowser`)

Closes #353