### PR TITLE
fix: update types to include constants in types.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,14 @@ declare namespace Bowser {
 
   function parse(UA: string): Parser.ParsedResult;
 
+  /**
+   * Constants exposed via bowser getters
+   */
+  const BROWSER_MAP: Record<string, string>;
+  const ENGINE_MAP: Record<string, string>;
+  const OS_MAP: Record<string, string>;
+  const PLATFORMS_MAP: Record<string, string>;
+
   namespace Parser {
     interface Parser {
       constructor(UA: string, skipParsing?: boolean): Parser.Parser;

--- a/src/bowser.js
+++ b/src/bowser.js
@@ -5,7 +5,7 @@
  * MIT License | (c) Denis Demchenko 2015-2019
  */
 import Parser from './parser.js';
-import {
+export {
   BROWSER_MAP,
   ENGINE_MAP,
   OS_MAP,

--- a/src/bowser.js
+++ b/src/bowser.js
@@ -5,7 +5,7 @@
  * MIT License | (c) Denis Demchenko 2015-2019
  */
 import Parser from './parser.js';
-export {
+import {
   BROWSER_MAP,
   ENGINE_MAP,
   OS_MAP,
@@ -74,4 +74,10 @@ class Bowser {
   }
 }
 
+export {
+  BROWSER_MAP,
+  ENGINE_MAP,
+  OS_MAP,
+  PLATFORMS_MAP,
+} from './constants.js';
 export default Bowser;


### PR DESCRIPTION
This PR adds the exposed maps to the types definition.

Also exports directly, but that change can be reverted.