### PR TITLE
add toLowerCase option to getBrowserName in typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,10 +43,11 @@ declare namespace Bowser {
 
       /**
        * Get browser's name
+       * @param {Boolean} [toLowerCase] return lower-cased value
        * @return {String} Browser's name or an empty string
        */
 
-      getBrowserName(): string;
+      getBrowserName(toLowerCase?: boolean): string;
 
       /**
        * Get browser's version


### PR DESCRIPTION
[`getBrowserName`](https://github.com/lancedikson/bowser/blob/a990b6b2f63b8eb8dc686c6f5f0c8d71e66e9ae0/src/parser.js#L124) has `toLowerCase` option but it is lacked on typing