### PR TITLE
feat(browser): add detection for Miui Browser

### DIFF
--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -562,6 +562,21 @@ const browsersList = [
     },
   },
   {
+    test: [/MiuiBrowser/i],
+    describe(ua) {
+      const browser = {
+        name: 'Miui',
+      };
+      const version = Utils.getFirstMatch(/(?:MiuiBrowser)[\s/](\d+(\.?_?\d+)+)/i, ua);
+
+      if (version) {
+        browser.version = version;
+      }
+
+      return browser;
+    },
+  },
+  {
     test: [/chromium/i],
     describe(ua) {
       const browser = {

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -3026,3 +3026,18 @@
           type: "desktop"
         engine:
           name: "Blink"
+  Miui:
+    -
+      ua: "Mozilla/5.0 (Linux; U; Android 9; fr-fr; Redmi Note 8 Pro Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/11.9.3-"
+      spec:
+        browser:
+          name: "Miui"
+          version: "11.9.3"
+        os:
+          name: "Android"
+          version: "9"
+          versionName: "Pie"
+        platform:
+          type: "mobile"
+        engine:
+          name: "Blink"

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -3041,3 +3041,16 @@
           type: "mobile"
         engine:
           name: "Blink"
+    -
+      ua: "Mozilla/5.0 (Linux; U; Android 9; fr-fr; Redmi Note 8 Pro Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser"
+      spec:
+        browser:
+          name: "Miui"
+        os:
+          name: "Android"
+          version: "9"
+          versionName: "Pie"
+        platform:
+          type: "mobile"
+        engine:
+          name: "Blink"


### PR DESCRIPTION
### Overview
This adds support for detecting Xiaomi MiuiBrowser requested in #433 

### Test
```
// window.navigator.userAgent is:
// "Mozilla/5.0 (Linux; U; Android 9; fr-fr; Redmi Note 8 Pro Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/11.9.3-"

const Bowser = require("bowser");
console.log(Bowser.parse(window.navigator.userAgent));
```
outputs
```
{
  browser: { name: 'Miui', version: '11.9.3' },
  os: { name: 'Android', version: '9', versionName: 'Pie' },
  platform: { type: 'mobile' },
  engine: { name: 'Blink' }
}
```