### PR TITLE
feat: add support for using alias in 'is' method

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -474,10 +474,12 @@ class Parser {
    * Is anything? Check if the browser is called "anything",
    * the OS called "anything" or the platform called "anything"
    * @param {String} anything
+   * @param [includingAlias=false] The flag showing whether alias will be included into comparison
    * @returns {Boolean}
    */
-  is(anything) {
-    return this.isBrowser(anything) || this.isOS(anything) || this.isPlatform(anything);
+  is(anything, includingAlias = false) {
+    return this.isBrowser(anything, includingAlias) || this.isOS(anything)
+      || this.isPlatform(anything);
   }
 
   /**

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -165,6 +165,30 @@ test('Parser.is should pass', (t) => {
   t.is(parser.is('macos'), true);
 });
 
+test('Parser.is should pass when not including aliases', (t) => {
+  t.is(edgeParser.is('Microsoft Edge', false), true);
+  t.is(edgeParser.is('microsoft edge', false), true);
+  t.is(edgeParser.is('mIcrosoft eDge', false), true);
+  t.is(edgeParser.is('edge', false), false);
+  t.is(edgeParser.is('Edge', false), false);
+  t.is(edgeParser.is('desktop', false), false);
+  t.is(edgeParser.is('macos', false), false);
+  t.is(edgeParser.is('mobile', false), true);
+  t.is(edgeParser.is('android', false), true);
+});
+
+test('Parser.is should pass when including aliases', (t) => {
+  t.is(edgeParser.is('Microsoft Edge', true), true);
+  t.is(edgeParser.is('microsoft edge', true), true);
+  t.is(edgeParser.is('mIcrosoft eDge', true), true);
+  t.is(edgeParser.is('edge', true), true);
+  t.is(edgeParser.is('Edge', true), true);
+  t.is(edgeParser.is('desktop', true), false);
+  t.is(edgeParser.is('macos', true), false);
+  t.is(edgeParser.is('mobile', true), true);
+  t.is(edgeParser.is('android', true), true);
+});
+
 test('Parser.is using constants should pass', (t) => {
   t.is(parser.is(Bowser.BROWSER_MAP.opera), true);
   t.is(parser.is(Bowser.PLATFORMS_MAP.desktop), true);
@@ -198,4 +222,9 @@ test('Parser.isBrowser should pass when loosely checking', (t) => {
 test('Parser.isBrowser should pass for non-aliased browsers', (t) => {
   t.is(focusParser.isBrowser('Focus', true), true);
   t.is(focusParser.isBrowser('Focus', false), true);
+});
+
+test('Parser.isEngine should pass', (t) => {
+  t.is(parser.isEngine('blink'), true);
+  t.is(parser.isEngine('webkit'), false);
 });


### PR DESCRIPTION
### Overview
This adds support for using aliases in the `parser.is` method.
Requested in #389 

### Test 
```
// window.navigation.userAgent is:
// "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299"

const Bowser = require("bowser");
console.log(Bowser.getParser(window.navigation.userAgent).is('edge', true));
```
outputs
```
true
```