### PR TITLE
Add missing typescript property declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,6 +106,13 @@ declare namespace Bowser {
       getEngine(): EngineDetails;
 
       /**
+       * Get parsed engine's name
+       * @returns {String} Engine's name or an empty string
+       */
+
+      getEngineName(): string;
+
+      /**
        * Get parsed result
        * @return {ParsedResult}
        */


### PR DESCRIPTION
The method getEngineName exists both in the project and the official docs. It's just missing in the typescript declaration file.