### PR TITLE
docs: Fix simple typo, submenut -> submenu

### DIFF
--- a/docs/scripts/collapse.js
+++ b/docs/scripts/collapse.js
@@ -1,5 +1,5 @@
 function hideAllButCurrent(){
-    //by default all submenut items are hidden
+    //by default all submenu items are hidden
     //but we need to rehide them for search
     document.querySelectorAll("nav > ul > li > ul li").forEach(function(parent) {
         parent.style.display = "none";


### PR DESCRIPTION
There is a small typo in docs/scripts/collapse.js.

Should read `submenu` rather than `submenut`.

