### PR TITLE
feat: update types of parser methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,10 +130,11 @@ declare namespace Bowser {
        * Is anything? Check if the browser is called "anything",
        * the OS called "anything" or the platform called "anything"
        * @param {String} anything
+       * @param [includingAlias=false] The flag showing whether alias will be included into comparison
        * @returns {Boolean}
        */
 
-      is(anything: any): boolean;
+      is(anything: any, includingAlias?: boolean): boolean;
 
       /**
        * Parse full information about the browser
@@ -191,18 +192,41 @@ declare namespace Bowser {
 
       satisfies(checkTree: checkTree): boolean | undefined;
 
-       /**
+      /**
        * Check if the browser name equals the passed string
-       * @param browserName The string to compare with the browser name
+       * @param {string} browserName The string to compare with the browser name
        * @param [includingAlias=false] The flag showing whether alias will be included into comparison
        * @returns {boolean}
        */
 
-
       isBrowser(browserName: string, includingAlias?: boolean): boolean;
 
       /**
-       * Check if any of the given values satifies `.is(anything)`
+       * Check if the engine name equals the passed string
+       * @param {string} engineName The string to compare with the engine name
+       * @returns {boolean}
+       */
+
+      isEngine(engineName: string): boolean;
+
+      /**
+       * Check if the platform type equals the passed string
+       * @param {string} platformType The string to compare with the platform type
+       * @returns {boolean}
+       */
+
+      isPlatform(platformType: string): boolean;
+
+      /**
+       * Check if the OS name equals the passed string
+       * @param {string} osName The string to compare with the OS name
+       * @returns {boolean}
+       */
+
+      isOS(osName: string): boolean;
+
+      /**
+       * Check if any of the given values satisfies `.is(anything)`
        * @param {string[]} anythings
        * @returns {boolean} true if at least one condition is satisfied, false otherwise.
        */

--- a/src/parser.js
+++ b/src/parser.js
@@ -408,7 +408,7 @@ class Parser {
 
   /**
    * Check if the browser name equals the passed string
-   * @param browserName The string to compare with the browser name
+   * @param {string} browserName The string to compare with the browser name
    * @param [includingAlias=false] The flag showing whether alias will be included into comparison
    * @returns {boolean}
    */
@@ -459,14 +459,29 @@ class Parser {
     ) > -1;
   }
 
+  /**
+   * Check if the OS name equals the passed string
+   * @param {string} osName The string to compare with the OS name
+   * @returns {boolean}
+   */
   isOS(osName) {
     return this.getOSName(true) === String(osName).toLowerCase();
   }
 
+  /**
+   * Check if the platform type equals the passed string
+   * @param {string} platformType The string to compare with the platform type
+   * @returns {boolean}
+   */
   isPlatform(platformType) {
     return this.getPlatformType(true) === String(platformType).toLowerCase();
   }
 
+  /**
+   * Check if the engine name equals the passed string
+   * @param {string} engineName The string to compare with the engine name
+   * @returns {boolean}
+   */
   isEngine(engineName) {
     return this.getEngineName(true) === String(engineName).toLowerCase();
   }


### PR DESCRIPTION
- Add type to the second parameter (`includingAlias`) of `parser.is` to support TypeScript,
  related #437 
- Add types to the methods:
  - `parser.isEngine`
  - `parser.isPlatform`
  - `parser.isOS`