### PR TITLE
revert(index.d.ts): rollback default export to `=` syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/lancedikson/bowser
 // Definitions by: Alexander P. Cerutti <https://github.com/alexandercerutti>,
 
-export default Bowser;
+export = Bowser;
 export as namespace Bowser;
 
 declare namespace Bowser {


### PR DESCRIPTION
This reverts commit 0c7380dbf9ff607023249c864c98e4bd87aa3bcb.