### PR TITLE
fix: prevent Motorola Edge devices from being misidentified as Microsoft Edge

### DIFF
--- a/src/parser-browsers.js
+++ b/src/parser-browsers.js
@@ -745,7 +745,7 @@ const browsersList = [
     },
   },
   {
-    test: [/edg([ea]|ios)/i],
+    test: [/edg([ea]|ios)\//i],
     describe(ua) {
       const browser = {
         name: 'Microsoft Edge',

--- a/test/acceptance/useragentstrings.yml
+++ b/test/acceptance/useragentstrings.yml
@@ -392,6 +392,32 @@
         engine:
           name: "WebKit"
           version: "537.31"
+    -
+      ua: "Mozilla/5.0 (Linux; Android 16; motorola edge 60 fusion Build/W1VC36H.14-20-19; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/144.0.7559.132 Mobile Safari/537.36 IITtraderNative DCASupport1/5 Mobile"
+      spec:
+        browser:
+          name: "Chrome"
+          version: "144.0.7559.132"
+        os:
+          name: "Android"
+          version: "16"
+        platform:
+          type: "mobile"
+        engine:
+          name: "Blink"
+    -
+      ua: "Mozilla/5.0 (Linux; Android 15; motorola edge 50 fusion Build/V1UUIS35H.15-41-6-18-2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/145.0.7632.79 Mobile Safari/537.36 IITtraderNative DCASupport1/5 Mobile"
+      spec:
+        browser:
+          name: "Chrome"
+          version: "145.0.7632.79"
+        os:
+          name: "Android"
+          version: "15"
+        platform:
+          type: "mobile"
+        engine:
+          name: "Blink"
   Google Search:
     -
       ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/605.1"


### PR DESCRIPTION
## Summary

- Fixes #610: Motorola "Edge" series devices (e.g. motorola edge 60 fusion) were incorrectly identified as Microsoft Edge browser
- Changed the Edge browser detection regex from `/edg([ea]|ios)/i` to `/edg([ea]|ios)\//i` to require a trailing slash, matching only legitimate Edge tokens (`EdgA/`, `Edge/`, `EdgiOS/`)
- Added test cases for Motorola Edge 60 and Edge 50 fusion device UA strings

## Test Plan

- [x] All 71 existing tests pass
- [x] New Motorola Edge UA test cases parse as Chrome with correct versions
- [x] Manual verification confirms both affected UA strings now return Chrome